### PR TITLE
Add TutorialSearch to Courses

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The list provides awesome resources about each of them.
 
 
 - [Learn how to Build Robot Fleet Systems](https://www.theconstructsim.com/robot-fleet-management-ros2-open-rmf-training) - 3-day online training to help your team learn to integrate Open-RMF for robot fleet management.
+- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 
 

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The list provides awesome resources about each of them.
 
 
 - [Learn how to Build Robot Fleet Systems](https://www.theconstructsim.com/robot-fleet-management-ros2-open-rmf-training) - 3-day online training to help your team learn to integrate Open-RMF for robot fleet management.
-- [TutorialSearch](https://tutorialsearch.io/) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
+- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/ai-robotics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
 
 
 


### PR DESCRIPTION
Hi! This PR adds **TutorialSearch** to the *Courses* section.

### What is TutorialSearch?
[TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/ai-robotics) is a free, cross-platform search engine that indexes 50,000+ tutorials and courses from major learning platforms (Udemy, Skillshare, Pluralsight, and more) across 45+ categories — including programming, web development, AI/ML, cybersecurity, design, and more. No signup required.

It helps learners compare tutorials side-by-side by rating, price, and reviews before committing to a course, which I think makes it a useful addition to this list.

### Entry added
```
- [TutorialSearch](https://tutorialsearch.io/browse/ai-machine-learning/ai-robotics) - Free cross-platform search engine indexing 50,000+ tutorials from Udemy, Skillshare, Pluralsight, and other major learning platforms across 45+ categories.
```

Inserted in alphabetical order within the section. Happy to adjust formatting, description length, or placement if you'd like — just let me know!

Thanks for maintaining this list.